### PR TITLE
fix: logo and tagline height for linked elements

### DIFF
--- a/demos/basic.html
+++ b/demos/basic.html
@@ -16,7 +16,7 @@
 		<section class="o-header__section">
 	<div class="o-header__brand">
 		<a href="#">
-			<div class="o-header__logo o-header__logo--pearson"></div>
+			<span class="o-header__logo o-header__logo--pearson"></span>
 		</a>
 	</div>
 </section>

--- a/demos/basic.html
+++ b/demos/basic.html
@@ -15,7 +15,9 @@
 	<div class="o-header__container demo-container">
 		<section class="o-header__section">
 	<div class="o-header__brand">
-		<div class="o-header__logo o-header__logo--pearson"></div>
+		<a href="#">
+			<div class="o-header__logo o-header__logo--pearson"></div>
+		</a>
 	</div>
 </section>
 <section class="o-header__section o-header__section--right o-header__viewport-phone-sm--hidden">

--- a/demos/nav.html
+++ b/demos/nav.html
@@ -15,7 +15,9 @@
 	<div class="o-header__container ">
 		<section class="o-header__section">
 	<div class="o-header__brand o-header__viewport-phone-sm--hidden">
-		<div class="o-header__logo o-header__logo--pearson"></div>
+		<a href="#">
+			<div class="o-header__logo o-header__logo--pearson"></div>
+		</a>
 	</div>
 	<nav class="o-header__nav o-header__viewport-phone-sm--hidden o-header__viewport-phone--hidden">
 		<ul class="o-header__nav-items">

--- a/demos/nav.html
+++ b/demos/nav.html
@@ -16,7 +16,7 @@
 		<section class="o-header__section">
 	<div class="o-header__brand o-header__viewport-phone-sm--hidden">
 		<a href="#">
-			<div class="o-header__logo o-header__logo--pearson"></div>
+			<span class="o-header__logo o-header__logo--pearson"></span>
 		</a>
 	</div>
 	<nav class="o-header__nav o-header__viewport-phone-sm--hidden o-header__viewport-phone--hidden">

--- a/demos/src/html/basic-sections.html
+++ b/demos/src/html/basic-sections.html
@@ -1,6 +1,8 @@
 <section class="o-header__section">
 	<div class="o-header__brand">
-		<div class="o-header__logo o-header__logo--pearson"></div>
+		<a href="#">
+			<div class="o-header__logo o-header__logo--pearson"></div>
+		</a>
 	</div>
 </section>
 <section class="o-header__section o-header__section--right o-header__viewport-phone-sm--hidden">

--- a/demos/src/html/basic-sections.html
+++ b/demos/src/html/basic-sections.html
@@ -1,7 +1,7 @@
 <section class="o-header__section">
 	<div class="o-header__brand">
 		<a href="#">
-			<div class="o-header__logo o-header__logo--pearson"></div>
+			<span class="o-header__logo o-header__logo--pearson"></span>
 		</a>
 	</div>
 </section>

--- a/demos/src/html/nav-sections.html
+++ b/demos/src/html/nav-sections.html
@@ -1,6 +1,8 @@
 <section class="o-header__section">
 	<div class="o-header__brand o-header__viewport-phone-sm--hidden">
-		<div class="o-header__logo o-header__logo--pearson"></div>
+		<a href="#">
+			<div class="o-header__logo o-header__logo--pearson"></div>
+		</a>
 	</div>
 	<nav class="o-header__nav o-header__viewport-phone-sm--hidden o-header__viewport-phone--hidden">
 		<ul class="o-header__nav-items">

--- a/demos/src/html/nav-sections.html
+++ b/demos/src/html/nav-sections.html
@@ -1,7 +1,7 @@
 <section class="o-header__section">
 	<div class="o-header__brand o-header__viewport-phone-sm--hidden">
 		<a href="#">
-			<div class="o-header__logo o-header__logo--pearson"></div>
+			<span class="o-header__logo o-header__logo--pearson"></span>
 		</a>
 	</div>
 	<nav class="o-header__nav o-header__viewport-phone-sm--hidden o-header__viewport-phone--hidden">

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -12,7 +12,6 @@
 	text-decoration: none;
 	color: $o-header-link-color;
 	font-size: 16px;
-	outline-offset: -2px;
 
 	&:hover,
 	&:focus {

--- a/src/scss/_variables.scss
+++ b/src/scss/_variables.scss
@@ -17,6 +17,7 @@ $o-header-gray-80: oHeaderMakeGrayColor(80%);
 $o-header-gray-90: oHeaderMakeGrayColor(90%);
 
 // Basics
+$o-header-sprite-height: 16px !default;
 $o-header-height: 54px !default;
 $o-header-height-mobile: 44px !default;
 $o-header-padding-horizontal: 15px !default;

--- a/src/scss/header.scss
+++ b/src/scss/header.scss
@@ -27,6 +27,7 @@
 	a {
 		text-decoration: none;
 		color: $o-header-link-color;
+		outline-offset: -2px;
 
 		&:hover,
 		&:focus {

--- a/src/scss/logo-tagline.scss
+++ b/src/scss/logo-tagline.scss
@@ -3,6 +3,11 @@
 /// @link http://registry.origami.ft.com/components/o-header
 ////
 
+.o-header__logo,
+.o-header__tagline {
+	display: block;
+}
+
 .o-header__logo--pearson,
 .o-header__tagline--always-learning {
 	height: $o-header-height-mobile;

--- a/src/scss/logo-tagline.scss
+++ b/src/scss/logo-tagline.scss
@@ -5,18 +5,21 @@
 
 .o-header__logo--pearson,
 .o-header__tagline--always-learning {
-	height: 16px;
-	margin-top: ($o-header-height-mobile - 16) / 2;
+	height: $o-header-height-mobile;
 	background: url(oHeaderAsset('img/pearson-sprite.svg')) no-repeat;
 
 	@media (min-width: $o-header-desktop-min) {
-		margin-top: ($o-header-height - 16) / 2;
+		height: $o-header-height;
 	}
 }
 
 .o-header__logo--pearson {
 	width: 100px;
-	background-position: right 0;
+	background-position: right ($o-header-height-mobile - $o-header-sprite-height) / 2;
+
+	@media (min-width: $o-header-desktop-min) {
+		background-position: right ($o-header-height - $o-header-sprite-height) / 2;
+	}
 }
 
 .o-header__tagline {
@@ -26,4 +29,9 @@
 
 .o-header__tagline--always-learning {
 	width: 170px;
+	background-position: left ($o-header-height-mobile - $o-header-sprite-height) / 2;
+
+	@media (min-width: $o-header-desktop-min) {
+		background-position: left ($o-header-height - $o-header-sprite-height) / 2;
+	}
 }

--- a/src/scss/theme-light.scss
+++ b/src/scss/theme-light.scss
@@ -16,12 +16,30 @@
 		background-color: $o-header-nav-link-active-bg-light;
 	}
 
+	.o-header__logo--pearson,
+	.o-header__tagline--always-learning {
+		background-clip: content-box;
+		padding: (($o-header-height-mobile - $o-header-sprite-height) / 2) 0;
+
+		@media (min-width: $o-header-desktop-min) {
+			padding: (($o-header-height - $o-header-sprite-height) / 2) 0;
+		}
+	}
+
 	.o-header__logo--pearson {
-		background-position: right -16px;
+		background-position: right (($o-header-height-mobile - $o-header-sprite-height) / 2) - $o-header-sprite-height;
+
+		@media (min-width: $o-header-desktop-min) {
+			background-position: right (($o-header-height - $o-header-sprite-height) / 2) - $o-header-sprite-height;
+		}
 	}
 
 	.o-header__tagline--always-learning {
-		background-position: 0 -16px;
+		background-position: left (($o-header-height-mobile - $o-header-sprite-height) / 2) - $o-header-sprite-height;
+
+		@media (min-width: $o-header-desktop-min) {
+			background-position: left (($o-header-height - $o-header-sprite-height) / 2) - $o-header-sprite-height;
+		}
 	}
 
 	.o-dropdown-menu {


### PR DESCRIPTION
When the o-header__logo--pearson and o-header__tagline--always-learning elements are links, the element should fill the height of the header to make it easier for users to click the image link and for consistency with nav items.

Reviewers: @dstack 